### PR TITLE
Remove ping validation

### DIFF
--- a/flashblade/pure-fb-filesystem-replication/roles/purefb_filesystem_replication/tasks/replication.yml
+++ b/flashblade/pure-fb-filesystem-replication/roles/purefb_filesystem_replication/tasks/replication.yml
@@ -23,28 +23,6 @@
     dst_fb_token: "{{ combined_inventory[repl_vars.dst.fb_name].api_token }}"
   no_log: true
 
-- name: validation | Check connectivity for source FBServer
-  shell: ping -q -c 4 -W 1 {{ src_fb_url }}
-  register: src_ping_status
-  failed_when: false
-  changed_when: false
-
-- name: validation | Fail if source Flashblade server not reachable
-  fail:
-    msg: Source FB server {{ src_fb_url }} not reachable
-  when: "'100% packet loss' in src_ping_status.stdout"
-
-- name: validation | Check connectivity for target FBServer
-  shell: ping -q -c 4 -W 1 {{ dst_fb_url }}
-  register: dst_ping_status
-  failed_when: false
-  changed_when: false
-
-- name: validation | Fail if target Flashblade server not reachable
-  fail:
-    msg: Target FB server {{ dst_fb_url }} not reachable
-  when: "'100% packet loss' in dst_ping_status.stdout"
-
 - name: validation | Check if reachable fb_host is FB server or not to fail fast
   uri:
     url: https://{{ src_fb_url }}/api/api_version

--- a/flashblade/pure-fb-objectstore-replication/roles/purefb_object_replication/tasks/fb-aws_replication.yml
+++ b/flashblade/pure-fb-objectstore-replication/roles/purefb_object_replication/tasks/fb-aws_replication.yml
@@ -26,17 +26,6 @@
     src_fb_token: "{{ combined_inventory[repl_vars.src.server].api_token }}"
   no_log: true
 
-- name: validation | Check connectivity for source FBServer
-  shell: ping -q -c 4 -W 1 {{ src_fb_url }}
-  register: src_ping_status
-  failed_when: false
-  changed_when: false
-
-- name: validation | Fail if source Flashblade server not reachable
-  fail:
-    msg: Source FB server {{ src_fb_url }} not reachable
-  when: "'100% packet loss' in src_ping_status.stdout"
-
 - name: validation | Check if reachable fb_host is FB server or not to fail fast
   uri:
     url: https://{{ src_fb_url }}/api/api_version

--- a/flashblade/pure-fb-objectstore-replication/roles/purefb_object_replication/tasks/fb-fb_replication.yml
+++ b/flashblade/pure-fb-objectstore-replication/roles/purefb_object_replication/tasks/fb-fb_replication.yml
@@ -37,28 +37,6 @@
     dst_fb_token: "{{ combined_inventory[repl_vars.dst.server].api_token }}"
   no_log: true
 
-- name: validation | Check connectivity for source FBServer
-  shell: ping -q -c 4 -W 1 {{ src_fb_url }}
-  register: src_ping_status
-  failed_when: false
-  changed_when: false
-
-- name: validation | Fail if source Flashblade server not reachable
-  fail:
-    msg: Source FB server {{ src_fb_url }} not reachable
-  when: "'100% packet loss' in src_ping_status.stdout"
-
-- name: validation | Check connectivity for target FBServer
-  shell: ping -q -c 4 -W 1 {{ dst_fb_url }}
-  register: dst_ping_status
-  failed_when: false
-  changed_when: false
-
-- name: validation | Fail if target Flashblade server not reachable
-  fail:
-    msg: Target FB server {{ dst_fb_url }} not reachable
-  when: "'100% packet loss' in dst_ping_status.stdout"
-
 - name: validation | Check if reachable fb_host is FB server or not to fail fast
   uri:
     url: https://{{ src_fb_url }}/api/api_version


### PR DESCRIPTION
There may be reasons why pinging the local or target FB may not work (eg ICMP blocked), but API connectivity does, so these tests are overkill. 